### PR TITLE
Fix for NullReferenceException at Mono.ILASM.ILParser.case_442

### DIFF
--- a/Mobius.ILASM/ilasm/parser/ILParser.cs
+++ b/Mobius.ILASM/ilasm/parser/ILParser.cs
@@ -4495,16 +4495,27 @@ namespace Mono.ILASM
         }
 
         void case_441()
-#line 2152 "C:\Apps\mono\mcs\ilasm\parser\ILParser.jay"
+#line default
         {
+            if (codegen.CurrentTypeDef == null)
+            {
+                logger.Error(tokenizer.Location, $"Method '{codegen.CurrentMethodDef.Name}' is outside class scope and cannot be an override.");
+                return;
+            }
+
             codegen.CurrentTypeDef.AddOverride(codegen.CurrentMethodDef,
                     (BaseTypeRef)yyVals[-2 + yyTop], (string)yyVals[0 + yyTop]);
-
         }
 
         void case_442()
-#line 2158 "C:\Apps\mono\mcs\ilasm\parser\ILParser.jay"
+#line default
         {
+            if (codegen.CurrentTypeDef == null)
+            {
+                logger.Error(tokenizer.Location, $"Method '{codegen.CurrentMethodDef.Name}' is outside class scope and cannot be an override.");
+                return;
+            }
+
             codegen.CurrentTypeDef.AddOverride(codegen.CurrentMethodDef.Signature,
                 (BaseMethodRef)yyVals[0 + yyTop]);
         }

--- a/Mobius.ILASM/ilasm/parser/ILParser.jay
+++ b/Mobius.ILASM/ilasm/parser/ILParser.jay
@@ -2150,14 +2150,26 @@ method_decl		: D_EMITBYTE int32
 			| D_VTENTRY int32 COLON int32 
 			| D_OVERRIDE type_spec DOUBLE_COLON method_name
                           {
+                                if (codegen.CurrentTypeDef == null)
+                                {
+                                    logger.Error(tokenizer.Location, $"Method '{codegen.CurrentMethodDef.Name}' is outside class scope and cannot be an override.");
+                                    return;
+                                }
+
                                 codegen.CurrentTypeDef.AddOverride (codegen.CurrentMethodDef,
                                         (BaseTypeRef) $2, (string) $4);
                                 
                           }
 			| D_OVERRIDE K_METHOD method_ref
                           {
-				codegen.CurrentTypeDef.AddOverride (codegen.CurrentMethodDef.Signature,
-					(BaseMethodRef) $3);
+                                if (codegen.CurrentTypeDef == null)
+                                {
+                                    logger.Error(tokenizer.Location, $"Method '{codegen.CurrentMethodDef.Name}' is outside class scope and cannot be an override.");
+                                    return;
+                                }
+
+                                codegen.CurrentTypeDef.AddOverride (codegen.CurrentMethodDef.Signature,
+                                        (BaseMethodRef) $3);
                           }
 			| D_OVERRIDE K_METHOD call_conv type type_spec DOUBLE_COLON method_name
 			  OPEN_ANGLE_BRACKET OPEN_BRACKET int32 CLOSE_BRACKET CLOSE_ANGLE_BRACKET


### PR DESCRIPTION
The following code causes an exception:
```
.method private final hidebysig newslot virtual 
	instance void MoveNext() cil managed 
{
    .override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext()   
    ret
}
```

The reason is it tries to add the override to `CurrentTypeDef`, but that is null at that point.
I wasn't able to regenerate the .cs properly (will need #7), so I updated it manually.

Unfortunately I also didn't have time to add a test (I added one in SharpLab itself, but not in this project).