### PR TITLE
Fix exception on non-XML format of .permissionset under .NET Framework (still not supported, but does not crash)

### DIFF
--- a/Mobius.ILASM/infrastructure/CurrentRuntime.cs
+++ b/Mobius.ILASM/infrastructure/CurrentRuntime.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Mobius.ILasm.infrastructure
+{
+    internal static class CurrentRuntime
+    {
+        public static bool IsNetFramework { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
This one is a bit tricky.

In my understanding, current version ILAsm behaves as following:
* On .NET Core or .NET 5, `.permissionset` is always silently dropped, whatever the format
(since CAS is a legacy feature, .NET Core always returns `null` from `PermissionSetAttribute.CreatePermissionSet`, without trying to parse whatever is passed into the attribute)
* On .NET Framework:
  * If `.permissionset` uses XML format (first edition of .NET ECMA spec), it will be handled correctly
  * If `.permissionset` uses blob format (newer versions of .NET ECMA spec), it will crash with a XmlException

I have updated it to the following:
* On .NET Core or .NET 5, `.permissionset` will still be skipped, but will report a warning:
"Code Access Security is not supported on this runtime. This permission set will be ignored."
* On .NET Framework:
  * If `.permissionset` uses XML format, it will be handled correctly
  * If `.permissionset` uses blob format, it will report a warning:
    "Newer (non-XML) permission set format is not yet supported by this library. This permission set will be ignored."
 
Now, this is a bit biased towards SharpLab as I don't see `.permissionset` support as an essential there.
Also, since it is only relevant to .NET Framework, spending high effort on permission set support might not be justified.

However please let me know if you would prefer for it to be an error instead.