### PR TITLE
Avoid likely unintended exception on duplicate signature (error will still be reported)

### DIFF
--- a/Mobius.ILASM/ilasm/codegen/TypeDef.cs
+++ b/Mobius.ILASM/ilasm/codegen/TypeDef.cs
@@ -242,6 +242,7 @@ namespace Mono.ILASM
             {
                 logger.Error(methoddef.StartLocation, "Duplicate method declaration: " + methoddef.Signature);
                 errors[nameof(TypeDef)] = $"Duplicate method declaration: {methoddef.Signature}";
+                return;
             }
 
             method_table.Add(methoddef.Signature, methoddef);


### PR DESCRIPTION
The code already checks the duplicate and reports it as an error, but then it continues to add it anyways and throws -- which looks like a bug.