### PR TITLE
Add basic .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+﻿root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true


### PR DESCRIPTION
Adding basic `.editorconfig`, for two main reasons:

- Ensures newline standard is picked up independently from the developer's OS
- When ILAsm is used as a submodule (e.g. in SharpLab for now), it won't pick .editorconfig from the parent project

(This is the last PR I plan for today, and I think I only have one more ILAsm issue in SharpLab overall. Thanks a lot!)