### PR TITLE
Return `false` from the driver if `codegen.Write` failed

### DIFF
--- a/Mobius.ILASM/Driver.cs
+++ b/Mobius.ILASM/Driver.cs
@@ -136,6 +136,9 @@ namespace Mobius.ILasm.Core
                     //File.Delete(output_file);
                     throw;
                 }
+
+                if (errors.Any())
+                    return false;
             }
             catch (ILAsmException e)
             {


### PR DESCRIPTION
Previously driver did not check for errors coming from `codegen.Write()`, only from `Process`.
However there are some checks done in `codegen.Write`, e.g. whether method labels are correct.

For example, this code would cause driver to return `true`, even though codegen bailed on the method and produced an incomplete (broken) assembly:
```
.method static void M () cil managed
{
    br IL_0001
}
```

Again only had time for tests on SharpLab side, but I'll aim to include proper tests in the future PRs.